### PR TITLE
Allow token-based login and return API token

### DIFF
--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -3,48 +3,77 @@
 namespace App\Http\Controllers\API;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
 use Auth;
 use Hash;
 use Illuminate\Http\Request;
+use Laravel\Sanctum\PersonalAccessToken;
 
 class AuthController extends Controller
 {
     public function login(Request $request)
     {
         $request->validate([
-            'username' => 'required|string',
-            'password' => 'required|string|',
+            'username' => 'required_without:token|string',
+            'password' => 'required_without:token|string',
+            'token' => 'nullable|string',
         ]);
         $login = $request->input('username');
         $password = $request->input('password');
-        $fieldType = filter_var($login, FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
-        $credentials = [
-            $fieldType => $login,
-            'password' => $password,
+        $incomingToken = $request->input('token');
+
+        $roleMap = [
+            'siswa' => 'student',
+            'sekolah' => 'school',
         ];
 
-        if (Auth::attempt($credentials)) {
+        if ($incomingToken) {
+            $accessToken = PersonalAccessToken::findToken($incomingToken);
+
+            if (! $accessToken || ! ($accessToken->tokenable instanceof User)) {
+                return response()->json(['success' => false, 'message' => 'Invalid token'], 401);
+            }
+
+            $user = $accessToken->tokenable;
+
+            if ($login) {
+                $fieldType = filter_var($login, FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
+
+                if ($user->$fieldType !== $login) {
+                    return response()->json(['success' => false, 'message' => 'Token does not match the provided user'], 401);
+                }
+            }
+
+            $plainTextToken = $incomingToken;
+        } else {
+            $fieldType = filter_var($login, FILTER_VALIDATE_EMAIL) ? 'email' : 'username';
+            $credentials = [
+                $fieldType => $login,
+                'password' => $password,
+            ];
+
+            if (! Auth::attempt($credentials)) {
+                return response()->json(['success' => false, 'message' => 'Invalid email or password'], 401);
+            }
+
             $user = Auth::user();
             $token = $user->createToken('API Token');
-            $roleMap = [
-                'siswa' => 'student',
-                'sekolah' => 'school',
-            ];
+            $plainTextToken = $token->plainTextToken;
             $request->session()->regenerate();
-            $userRole = $user->role;
-            $property = $roleMap[$userRole] ?? null;
-            $biodata = $property ? $user->$property : null;
-
-            return response()->json([
-                'success' => true,
-                'user' => $user,
-                'biodata' => $biodata,
-                'role' => $user->role,
-                'permissions' => $user->getAllPermissions()->pluck('name'), // Assuming user has permissions
-            ])->cookie('access_token', $token->plainTextToken, 60, null, null, true, true);
-        } else {
-            return response()->json(['success' => false, 'message' => 'Invalid email or password'], 401);
         }
+
+        $userRole = $user->role;
+        $property = $roleMap[$userRole] ?? null;
+        $biodata = $property ? $user->$property : null;
+
+        return response()->json([
+            'success' => true,
+            'user' => $user,
+            'biodata' => $biodata,
+            'role' => $user->role,
+            'permissions' => $user->getAllPermissions()->pluck('name'),
+            'token' => $plainTextToken,
+        ])->cookie('access_token', $plainTextToken, 60, null, null, true, true);
     }
 
     public function logout(Request $request)


### PR DESCRIPTION
## Summary
- update the API login endpoint to optionally authenticate with an existing Sanctum token
- include the issued token in the login response for mobile clients while keeping the cookie behaviour

## Testing
- php artisan test *(fails: missing vendor/autoload.php in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68de2aa24f78832f958a48f9c3afbe20