### PR TITLE
Add Docker setup for Render with PHP 8.4 stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PORT=8080
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        software-properties-common \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release \
+        unzip \
+        supervisor \
+        nginx \
+        mysql-server \
+        gettext-base \
+    && add-apt-repository ppa:ondrej/php \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        php8.4-fpm \
+        php8.4-cli \
+        php8.4-mbstring \
+        php8.4-xml \
+        php8.4-curl \
+        php8.4-mysql \
+        php8.4-zip \
+        php8.4-bcmath \
+        php8.4-gd \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+RUN mkdir -p /etc/nginx/templates /run/php \
+    && rm -f /etc/nginx/sites-enabled/default /etc/nginx/sites-available/default
+
+WORKDIR /var/www/html
+
+COPY . /var/www/html
+
+RUN composer install --no-dev --no-interaction --prefer-dist --no-scripts \
+    && chown -R www-data:www-data storage bootstrap/cache
+
+COPY docker/nginx.conf /etc/nginx/templates/ppdb.conf.template
+COPY docker/supervisord.conf /etc/supervisor/conf.d/ppdb.conf
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+    && ln -sf /dev/stdout /var/log/nginx/access.log \
+    && ln -sf /dev/stderr /var/log/nginx/error.log
+
+EXPOSE 8080
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT_VALUE=${PORT:-8080}
+export PORT=${PORT_VALUE}
+
+# Render expects the service to listen on $PORT. Build the nginx config on each boot.
+envsubst '$PORT' < /etc/nginx/templates/ppdb.conf.template > /etc/nginx/conf.d/default.conf
+
+# Ensure runtime directories exist with correct ownership.
+mkdir -p /run/php
+chown www-data:www-data /run/php
+
+mkdir -p /var/run/mysqld
+chown mysql:mysql /var/run/mysqld
+
+if [ ! -d "/var/lib/mysql/mysql" ]; then
+    echo "Initializing MySQL data directory"
+    mysqld --initialize-insecure --user=mysql
+fi
+
+exec /usr/bin/supervisord -n -c /etc/supervisor/supervisord.conf

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,30 @@
+server {
+    listen       ${PORT} default_server;
+    listen       [::]:${PORT} default_server;
+    server_name  _;
+
+    root /var/www/html/public;
+    index index.php index.html;
+
+    access_log /var/log/nginx/access.log;
+    error_log  /var/log/nginx/error.log;
+
+    location / {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_index index.php;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_pass unix:/run/php/php8.4-fpm.sock;
+    }
+
+    location ~ /\.ht {
+        deny all;
+    }
+
+    client_max_body_size 64M;
+    sendfile on;
+}

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,0 +1,27 @@
+[supervisord]
+nodaemon=true
+user=root
+logfile=/var/log/supervisor/supervisord.log
+pidfile=/var/run/supervisord.pid
+
+[program:php-fpm]
+command=/usr/sbin/php-fpm8.4 --nodaemonize
+user=www-data
+autostart=true
+autorestart=true
+stopsignal=QUIT
+
+[program:nginx]
+command=/usr/sbin/nginx -g "daemon off;"
+autostart=true
+autorestart=true
+priority=20
+stopsignal=QUIT
+
+[program:mysql]
+command=/usr/sbin/mysqld
+user=mysql
+autostart=true
+autorestart=true
+priority=10
+stopsignal=TERM


### PR DESCRIPTION
## Summary
- add a Render-ready Dockerfile that installs PHP 8.4, nginx, and MySQL
- provide supervisor, nginx, and entrypoint configuration to manage services and Render's PORT

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ee8b239ee0832f8444e5915474cfdf