### PR TITLE
Revamp front page navigation styling

### DIFF
--- a/front_end/src/components/NavBar.vue
+++ b/front_end/src/components/NavBar.vue
@@ -1,85 +1,192 @@
 <template>
-	<nav id="navbar" class="fixed top-0 left-0 z-10 w-full text-neutral-800 shadow-sm bg-white transition-all duration-300 h-16">
-		<div class="flex flex-col max-w-screen-xl px-8 mx-auto lg:items-center lg:justify-between lg:flex-row py-2">
-			<div class="flex flex-col lg:flex-row items-center space-x-4 xl:space-x-8">
-				<div class="w-full flex flex-row items-center justify-between py-2">
-					<div>
-						<RouterLink to="/">
-							<img :src="logoppdb" class="w-24 xl:w-28" alt="Logo PPDB" />
-						</RouterLink>
-					</div>
-					<button class="rounded-sm lg:hidden focus:outline-none focus:shadow-outline" @click="open = !open">
-						<SegmentIcon v-if="!open" :size="24" />
-						<CloseIcon v-else :size="24" />
-					</button>
-				</div>
-			</div>
-			<div class="flex items-center" :class="[open ? 'justify-start' : 'justify-end ml-auto']">
-				<ul
-					:class="[open ? 'flex' : 'hidden lg:flex']"
-					class="w-full h-auto flex flex-col flex-grow lg:items-center pb-4 lg:pb-0 lg:justify-end lg:flex-row origin-top duration-300 xl:space-x-2 space-y-3 lg:space-y-0">
-					<DropDownMenu title="Informasi" :items="dropdownAItems" />
-					<NavLink name="Statistik" url="/statistik" />
-				</ul>
-			</div>
+        <nav
+                id="navbar"
+                class="fixed top-0 left-0 z-50 w-full bg-white/80 backdrop-blur-lg shadow-sm transition-all duration-300"
+        >
+                <div class="mx-auto flex max-w-screen-xl flex-col px-6">
+                        <div class="flex items-center justify-between py-4">
+                                <RouterLink
+                                        to="/"
+                                        class="flex items-center gap-3 text-2xl font-bold text-gray-800"
+                                        aria-label="Beranda PPDB"
+                                >
+                                        <img :src="logoppdb" class="w-10" alt="Logo PPDB" />
+                                        <span class="hidden sm:inline">
+                                                <span class="text-blue-600">PPDB</span>
+                                                <span class="text-gray-800"> Pro</span>
+                                        </span>
+                                </RouterLink>
 
-			<div :class="[open ? 'flex' : 'hidden lg:flex', 'space-x-3', 'ml-2']">
-				<router-link to="/login" class="bg-blue-200 hover:bg-blue-300 text-blue-800 font-bold py-2 px-4 rounded-full"> Login </router-link>
-			</div>
-		</div>
-	</nav>
+                                <div class="hidden items-center space-x-6 md:flex">
+                                        <ul class="flex items-center space-x-6 text-sm font-medium">
+                                                <DropDownMenu title="Informasi" :items="dropdownAItems" />
+                                                <NavLink name="Statistik" url="/statistik" />
+                                        </ul>
+                                        <router-link
+                                                to="/login"
+                                                class="flex items-center space-x-2 rounded-full bg-blue-600 px-5 py-2.5 font-semibold text-white shadow-lg shadow-blue-500/20 transition duration-300 hover:-translate-y-0.5 hover:bg-blue-700"
+                                        >
+                                                <svg
+                                                        class="h-5 w-5"
+                                                        xmlns="http://www.w3.org/2000/svg"
+                                                        viewBox="0 0 20 20"
+                                                        fill="currentColor"
+                                                >
+                                                        <path
+                                                                fill-rule="evenodd"
+                                                                d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z"
+                                                                clip-rule="evenodd"
+                                                        />
+                                                </svg>
+                                                <span>Login</span>
+                                        </router-link>
+                                </div>
+
+                                <div class="md:hidden">
+                                        <button
+                                                type="button"
+                                                class="text-gray-600 transition hover:text-blue-600 focus:outline-none"
+                                                aria-controls="mobile-menu"
+                                                :aria-expanded="open ? 'true' : 'false'"
+                                                @click="toggleMobileMenu"
+                                        >
+                                                <SegmentIcon v-if="!open" :size="28" />
+                                                <CloseIcon v-else :size="28" />
+                                        </button>
+                                </div>
+                        </div>
+
+                        <transition name="fade-slide">
+                                <div
+                                        v-if="open"
+                                        id="mobile-menu"
+                                        class="md:hidden border-t border-gray-100 bg-white"
+                                >
+                                        <div class="space-y-2 px-4 pb-4 pt-2">
+                                                <div>
+                                                        <button
+                                                                type="button"
+                                                                class="flex w-full items-center justify-between rounded-md px-2 py-2 text-left text-gray-600 transition hover:text-blue-600"
+                                                                :aria-expanded="mobileDropdownOpen ? 'true' : 'false'"
+                                                                @click="toggleMobileDropdown"
+                                                        >
+                                                                <span>Informasi</span>
+                                                                <svg
+                                                                        class="h-4 w-4 transition-transform duration-300"
+                                                                        :class="mobileDropdownOpen ? 'rotate-180' : ''"
+                                                                        fill="none"
+                                                                        stroke="currentColor"
+                                                                        viewBox="0 0 24 24"
+                                                                >
+                                                                        <path
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round"
+                                                                                stroke-width="2"
+                                                                                d="M19 9l-7 7-7-7"
+                                                                        />
+                                                                </svg>
+                                                        </button>
+                                                        <div
+                                                                v-if="mobileDropdownOpen"
+                                                                class="mt-1 space-y-1 border-l-2 border-blue-100 pl-4"
+                                                        >
+                                                                <RouterLink
+                                                                        v-for="(item, index) in dropdownAItems"
+                                                                        :key="`mobile-info-${index}`"
+                                                                        :to="item.url"
+                                                                        class="block py-2 text-sm text-gray-500 transition hover:text-blue-600"
+                                                                        @click="closeMobileMenus"
+                                                                >
+                                                                        {{ item.label }}
+                                                                </RouterLink>
+                                                        </div>
+                                                </div>
+                                                <RouterLink
+                                                        to="/statistik"
+                                                        class="block py-2 text-gray-600 transition hover:text-blue-600"
+                                                        @click="closeMobileMenus"
+                                                >
+                                                        Statistik
+                                                </RouterLink>
+                                                <router-link
+                                                        to="/login"
+                                                        class="block w-full rounded-full bg-blue-600 py-2.5 text-center font-semibold text-white transition hover:bg-blue-700"
+                                                        @click="closeMobileMenus"
+                                                >
+                                                        Login
+                                                </router-link>
+                                        </div>
+                                </div>
+                        </transition>
+                </div>
+        </nav>
 </template>
 
 <script setup lang="ts">
-// Import necessary components
-import { ref } from "vue"
+import { onMounted, onUnmounted, ref, watch } from "vue"
+import { useRoute } from "vue-router"
 import SegmentIcon from "@/components/Icon/SegmentIcon.vue"
 import CloseIcon from "@/components/Icon/CloseIcon.vue"
 import NavLink from "@/components/NavLink.vue"
 import DropDownMenu from "./UI/DropDownMenu.vue"
 import logoppdb from "@/assets/images/logo/logo-ppdb.png"
 
-// Reactive state for open dropdown and navbar
 const open = ref(false)
+const mobileDropdownOpen = ref(false)
 const dropdownAItems = [
-	{ label: "Sekolah", url: "/sekolah" },
-	{ label: "Persyaratan", url: "/persyaratan" },
+        { label: "Daftar Sekolah", url: "/sekolah" },
+        { label: "Persyaratan Umum", url: "/persyaratan" },
 ]
+
+const route = useRoute()
+
+const closeMobileMenus = () => {
+        open.value = false
+        mobileDropdownOpen.value = false
+}
+
+const toggleMobileMenu = () => {
+        open.value = !open.value
+        if (!open.value) {
+                mobileDropdownOpen.value = false
+        }
+}
+
+const toggleMobileDropdown = () => {
+        mobileDropdownOpen.value = !mobileDropdownOpen.value
+}
+
+watch(
+        () => route.fullPath,
+        () => {
+                closeMobileMenus()
+        },
+)
+
+const handleResize = () => {
+        if (window.innerWidth >= 768) {
+                closeMobileMenus()
+        }
+}
+
+onMounted(() => {
+        window.addEventListener("resize", handleResize)
+})
+
+onUnmounted(() => {
+        window.removeEventListener("resize", handleResize)
+})
 </script>
 
 <style>
-/* Keep the same style definitions as the original */
-.cover-gradient {
-	background: linear-gradient(169.4deg, rgba(57, 132, 244, 0.04) -6.01%, rgba(12, 211, 255, 0.04) 36.87%, rgba(47, 124, 240, 0.04) 78.04%, rgba(14, 101, 232, 0.04) 103.77%);
-}
-.cover-gradient-2 {
-	background: linear-gradient(169.4deg, rgba(57, 132, 244, 0.1) -6.01%, rgba(12, 211, 255, 0.1) 36.87%, rgba(47, 124, 240, 0.1) 78.04%, rgba(14, 101, 232, 0.1) 103.77%);
-}
-.bg-blue-gradient,
-.text-gradient {
-	background: linear-gradient(136.91deg, #468ef9 -12.5%, #0c66ee 107.5%);
+.fade-slide-enter-active,
+.fade-slide-leave-active {
+        transition: all 0.2s ease;
 }
 
-/* Transition styles */
-.slide-enter-active {
-	transition-duration: 0.3s;
-	transition-timing-function: ease-in;
-}
-
-.slide-leave-active {
-	transition-duration: 0.3s;
-	transition-timing-function: cubic-bezier(0, 1, 0.5, 1);
-}
-
-.slide-enter-to,
-.slide-leave {
-	max-height: 100px;
-	overflow: hidden;
-}
-
-.slide-enter,
-.slide-leave-to {
-	overflow: hidden;
-	max-height: 0;
+.fade-slide-enter-from,
+.fade-slide-leave-to {
+        opacity: 0;
+        transform: translateY(-4px);
 }
 </style>

--- a/front_end/src/components/NavLink.vue
+++ b/front_end/src/components/NavLink.vue
@@ -1,15 +1,17 @@
 <template>
-	<li class="w-full">
-		<router-link class="md:px-4 py-2 text-sm bg-transparent rounded-lg text-[#666666] hover:text-gray-900 focus:outline-none focus:shadow-outline" :to="url">
-			{{ name }}
-		</router-link>
-	</li>
+        <li>
+                <router-link
+                        class="text-sm font-medium text-gray-600 transition duration-300 hover:text-blue-600"
+                        :to="url"
+                >
+                        {{ name }}
+                </router-link>
+        </li>
 </template>
 
 <script setup lang="ts">
-// Define props using defineProps from Vue
 defineProps<{
-	name: string
-	url: string
+        name: string
+        url: string
 }>()
 </script>

--- a/front_end/src/components/UI/DropDownMenu.vue
+++ b/front_end/src/components/UI/DropDownMenu.vue
@@ -1,52 +1,69 @@
 <template>
-	<li class="relative" @mouseover="openDropdown" @mouseleave="closeDropdown" @click.prevent="toggleDropdown">
-		<a class="flex items-center justify-between md:px-4 py-2 text-sm bg-transparent rounded-lg text-[#666666] hover:text-gray-900 focus:outline-none focus:shadow-outline">
-			{{ title }}
-			<svg class="w-2.5 h-2.5 ml-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 10 6">
-				<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4" />
-			</svg>
-		</a>
+        <li
+                class="relative"
+                @mouseenter="openDropdown"
+                @mouseleave="closeDropdown"
+        >
+                <button
+                        type="button"
+                        class="dropdown-trigger flex items-center space-x-1 rounded-md px-2 py-2 text-sm font-medium text-gray-600 transition duration-300 hover:text-blue-600 focus:outline-none"
+                        :aria-expanded="isOpen ? 'true' : 'false'"
+                        @click.stop="toggleDropdown"
+                >
+                        <span>{{ title }}</span>
+                        <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                        </svg>
+                </button>
 
-		<!-- Dropdown menu -->
-		<div v-if="isOpen" class="z-10 font-normal bg-white divide-y divide-gray-100 shadow w-44 dark:bg-gray-700 dark:divide-gray-600 absolute">
-			<ul class="py-2 text-sm text-gray-700 dark:text-gray-200">
-				<li v-for="(item, index) in items" :key="index">
-					<RouterLink :to="item.url" class="block px-4 py-2 hover:bg-blue-100 hover:rounded-md dark:hover:bg-blue-200 dark:hover:text-white">
-						{{ item.label }}
-					</RouterLink>
-				</li>
-			</ul>
-		</div>
-	</li>
+                <div
+                        class="dropdown-menu absolute left-0 mt-2 w-56 origin-top rounded-md bg-white py-2 shadow-lg ring-1 ring-black/5 transition duration-150 ease-out"
+                        :class="isOpen ? 'scale-100 opacity-100 pointer-events-auto' : 'scale-95 opacity-0 pointer-events-none'"
+                >
+                        <ul class="space-y-1 text-sm text-gray-700">
+                                <li v-for="(item, index) in items" :key="index">
+                                        <RouterLink
+                                                :to="item.url"
+                                                class="block px-4 py-2 transition duration-150 hover:bg-blue-50 hover:text-blue-600"
+                                                @click="selectItem"
+                                        >
+                                                {{ item.label }}
+                                        </RouterLink>
+                                </li>
+                        </ul>
+                </div>
+        </li>
 </template>
 
 <script setup lang="ts">
 import { ref } from "vue"
 
-// Define props for the component
 defineProps<{
-	title: string
-	items: Array<{ label: string; url: string }>
+        title: string
+        items: Array<{ label: string; url: string }>
 }>()
 
-// State to manage the dropdown's open/closed state
 const isOpen = ref(false)
 
-// Open and close the dropdown
 const openDropdown = () => {
-	isOpen.value = true
+        isOpen.value = true
 }
 
 const closeDropdown = () => {
-	isOpen.value = false
+        isOpen.value = false
 }
 
-// Toggle the dropdown
 const toggleDropdown = () => {
-	isOpen.value = !isOpen.value
+        isOpen.value = !isOpen.value
+}
+
+const selectItem = () => {
+        closeDropdown()
 }
 </script>
 
 <style scoped>
-/* Additional styles if needed */
+.dropdown-menu {
+        transform-origin: top;
+}
 </style>

--- a/front_end/src/views/HomeView.vue
+++ b/front_end/src/views/HomeView.vue
@@ -1,64 +1,117 @@
 <template>
-	<section class="flex max-h-[calc(100vh-4rem)] min-h-[calc(100vh-4rem)] lg:min-h-0 mb-2">
-		<div class="grid max-w-screen-xl px-4 py-4 sm:py-6 lg:py-8 mx-auto mb-4 lg:mb-8 lg:gap-8 xl:gap-0 lg:py-16 lg:grid-cols-12">
-			<!-- Image container - reduced padding/margin on mobile -->
-			<div class="mb-4 sm:mb-6 lg:mb-0 order-1 lg:order-2 lg:mt-0 lg:col-span-5 flex justify-center lg:justify-end">
-				<GradeIllustration class="w-full h-auto text-blue-700" />
-			</div>
+        <div class="bg-gray-50 text-gray-700">
+                <section class="relative bg-white pt-16 pb-24 overflow-hidden">
+                        <div class="absolute inset-0 bg-gradient-to-br from-blue-50 to-indigo-100 opacity-60"></div>
+                        <div class="container mx-auto px-6 relative z-10 flex flex-col lg:flex-row items-center">
+                                <div class="lg:w-1/2 text-center lg:text-left">
+                                        <span class="text-blue-600 font-semibold uppercase tracking-wider">PPDB Online 2025/2026</span>
+                                        <h1 class="text-4xl md:text-6xl font-extrabold text-gray-800 mt-2 leading-tight tracking-tight">
+                                                {{ heroTitle }}
+                                        </h1>
+                                        <p class="mt-6 text-lg text-gray-600 max-w-xl mx-auto lg:mx-0">
+                                                Selamat datang di portal resmi penerimaan siswa baru. Mulai langkah pertama pendidikan terbaik untuk masa depan.
+                                        </p>
+                                        <div class="mt-10 flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
+                                                <router-link
+                                                        to="/daftar"
+                                                        class="inline-flex items-center justify-center px-8 py-4 bg-blue-600 text-white font-bold rounded-full hover:bg-blue-700 transition duration-300 shadow-xl shadow-blue-500/30 transform hover:scale-[1.02]"
+                                                >
+                                                        Daftar Sekarang
+                                                </router-link>
+                                                <a
+                                                        href="#video-tutorial"
+                                                        class="inline-flex items-center justify-center px-8 py-4 text-gray-700 font-bold rounded-full hover:bg-gray-200 transition duration-300"
+                                                >
+                                                        Lihat Tutorial ▸
+                                                </a>
+                                        </div>
+                                </div>
+                                <div class="lg:w-1/2 mt-12 lg:mt-0">
+                                        <GradeIllustration class="w-full h-auto" />
+                                </div>
+                        </div>
+                        <div class="absolute bottom-0 left-0 w-full overflow-hidden leading-none" style="transform: translateY(1px);">
+                                <svg viewBox="0 0 1440 100" class="relative block w-full h-20 text-gray-50" fill="currentColor">
+                                        <path d="M1440 100H0V0c.07 22 3.8 44 11 65 14 43 45 80 92 92 50 13 106 3 158-12 115-32 231-77 353-85 137-9 278 18 409 53 118 32 235 69 317 77z"></path>
+                                </svg>
+                        </div>
+                </section>
 
-			<!-- Content container - adjusted spacing -->
-			<div class="order-2 lg:order-1 place-self-center lg:col-span-7">
-				<h1 class="max-w-2xl mb-2 sm:mb-4 text-3xl sm:text-4xl font-extrabold tracking-tight text-gray-800 leading-none md:text-5xl xl:text-6xl dark:text-white">
-					Selamat Datang di web PPDB Kuantan Singingi
-				</h1>
-				<p class="max-w-2xl mb-4 sm:mb-6 font-light text-gray-600 lg:mb-8 md:text-lg lg:text-xl dark:text-gray-400">
-					Dengan PPDB, proses pendaftaran sekolah kini lebih mudah dan cepat. Ayo daftarkan sekolah Anda atau daftar sebagai calon siswa.
-				</p>
-				<div class="flex flex-wrap gap-3">
-					<router-link
-						to="/daftar"
-						class="inline-flex items-center justify-center px-4 sm:px-5 py-2 sm:py-3 text-base font-medium text-center text-white rounded-lg bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:ring-blue-300 dark:focus:ring-blue-900">
-						Daftar
-						<svg class="w-5 h-5 ml-2 -mr-1" fill="currentColor" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-							<path
-								fill-rule="evenodd"
-								d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
-								clip-rule="evenodd"></path>
-						</svg>
-					</router-link>
-				</div>
-			</div>
-		</div>
-	</section>
-	<section class="bg-gray-50 dark:bg-gray-800 py-8 w-full">
-		<div class="flex justify-center w-full">
-			<div class="rounded-lg shadow-lg bg-white w-full max-w-screen-xl mx-auto">
-				<a :href="ytURL as string" target="_blank">
-					<iframe
-						class="w-full rounded-t-lg h-60 sm:h-80 md:h-96"
-						:src="ytURL as string"
-						title="Tutorial PPDB Kuantan Singingi"
-						frameborder="0"
-						allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-						allowfullscreen>
-					</iframe>
-				</a>
-				<div class="p-6">
-					<h5 class="text-gray-900 text-xl font-medium mb-2">Video Tutorial Penggunaan web PPDB</h5>
-				</div>
-			</div>
-		</div>
-	</section>
+                <section class="py-20">
+                        <div class="container mx-auto px-6">
+                                <div class="text-center mb-12">
+                                        <h2 class="text-3xl md:text-4xl font-bold text-gray-800">Kenapa Memilih Kami?</h2>
+                                        <p class="mt-2 text-gray-600">Platform PPDB yang dirancang untuk kemudahan Anda.</p>
+                                </div>
+                                <div class="grid gap-8 md:grid-cols-3">
+                                        <div class="bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition duration-300 transform hover:-translate-y-2">
+                                                <div class="bg-blue-100 text-blue-600 rounded-full w-16 h-16 flex items-center justify-center mb-6">
+                                                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z" />
+                                                        </svg>
+                                                </div>
+                                                <h3 class="text-xl font-bold mb-2">Pendaftaran Mudah</h3>
+                                                <p class="text-gray-600">Proses pendaftaran yang simpel dan bisa dilakukan kapan saja, di mana saja.</p>
+                                        </div>
+                                        <div class="bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition duration-300 transform hover:-translate-y-2">
+                                                <div class="bg-green-100 text-green-600 rounded-full w-16 h-16 flex items-center justify-center mb-6">
+                                                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                                        </svg>
+                                                </div>
+                                                <h3 class="text-xl font-bold mb-2">Proses Transparan</h3>
+                                                <p class="text-gray-600">Pantau status pendaftaran Anda secara real-time dari dashboard.</p>
+                                        </div>
+                                        <div class="bg-white p-8 rounded-xl shadow-lg hover:shadow-2xl transition duration-300 transform hover:-translate-y-2">
+                                                <div class="bg-indigo-100 text-indigo-600 rounded-full w-16 h-16 flex items-center justify-center mb-6">
+                                                        <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z" />
+                                                        </svg>
+                                                </div>
+                                                <h3 class="text-xl font-bold mb-2">Dukungan Penuh</h3>
+                                                <p class="text-gray-600">Tim kami siap membantu jika Anda mengalami kendala saat proses pendaftaran.</p>
+                                        </div>
+                                </div>
+                        </div>
+                </section>
+
+                <section id="video-tutorial" class="bg-white py-20">
+                        <div class="container mx-auto px-6 text-center">
+                                <h2 class="text-3xl md:text-4xl font-bold text-gray-800">Video Tutorial Pendaftaran</h2>
+                                <p class="mt-2 text-gray-600 max-w-2xl mx-auto">Ikuti langkah-langkah pendaftaran dengan mudah melalui panduan video di bawah ini.</p>
+                                <div class="mt-10 max-w-4xl mx-auto shadow-2xl rounded-xl overflow-hidden">
+                                        <div class="relative" style="padding-top: 56.25%;">
+                                                <iframe
+                                                        class="absolute top-0 left-0 w-full h-full"
+                                                        :src="ytURL as string"
+                                                        title="Tutorial PPDB Kuantan Singingi"
+                                                        frameborder="0"
+                                                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                                        allowfullscreen
+                                                ></iframe>
+                                        </div>
+                                </div>
+                        </div>
+                </section>
+        </div>
 </template>
 
 <script setup lang="ts">
 import GradeIllustration from "@/components/Illustration/GradeIllustration.vue"
 import { useSetting } from "@/composable/useSetting"
-import { onMounted } from "vue"
+import { computed, onMounted } from "vue"
 
 const { settingData, fetchSetting, ytURL } = useSetting()
 
+const heroTitle = computed(() => {
+        const title = settingData.value?.header
+        if (typeof title === "string" && title.trim().length > 0) {
+                return title
+        }
+        return "Pendaftaran Sekolah Lebih Mudah & Cepat"
+})
+
 onMounted(async () => {
-	await fetchSetting()
+        await fetchSetting()
 })
 </script>


### PR DESCRIPTION
## Summary
- restyle the front-page navbar to match the new landing design while keeping the existing components and responsive behavior
- refresh the dropdown presentation and animations to align with the updated styling
- update nav link styling to use the new color palette

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ef6bdd74f0832fa1ca7115f9da5b05