### PR TITLE
Fix dropdown event handling and click-outside directive

### DIFF
--- a/front_end/src/components/UI/DropDownMenu.vue
+++ b/front_end/src/components/UI/DropDownMenu.vue
@@ -1,5 +1,6 @@
 <template>
         <li
+                ref="dropdownRef"
                 class="relative"
                 @mouseenter="openDropdown"
                 @mouseleave="closeDropdown"
@@ -45,7 +46,6 @@ defineProps<{
 
 const isOpen = ref(false)
 const dropdownRef = ref<HTMLElement | null>(null)
-let focusOutTimer: number | undefined
 
 const openDropdown = () => {
         isOpen.value = true
@@ -63,6 +63,19 @@ const selectItem = () => {
         closeDropdown()
 }
 
+const handleDocumentClick = (event: MouseEvent) => {
+        const target = event.target as Node | null
+        if (dropdownRef.value && target && !dropdownRef.value.contains(target)) {
+                closeDropdown()
+        }
+}
+
+const handleKeydown = (event: KeyboardEvent) => {
+        if (event.key === "Escape") {
+                closeDropdown()
+        }
+}
+
 onMounted(() => {
         document.addEventListener("click", handleDocumentClick)
         document.addEventListener("keydown", handleKeydown)
@@ -71,7 +84,6 @@ onMounted(() => {
 onBeforeUnmount(() => {
         document.removeEventListener("click", handleDocumentClick)
         document.removeEventListener("keydown", handleKeydown)
-        clearTimeout(focusOutTimer)
 })
 </script>
 

--- a/front_end/src/directives/clickOutsideDirective.ts
+++ b/front_end/src/directives/clickOutsideDirective.ts
@@ -13,18 +13,22 @@ interface ClickOutsideBinding extends DirectiveBinding {
 export const clickOutsideDirective = {
 	beforeMount(el: HTMLElementWithClickOutside, binding: ClickOutsideBinding) {
 		// Define the click handler
-		el.clickOutsideEvent = (_event: MouseEvent) => {
-			// Check if the click was outside the element
-			if (!(el === _event.target || el.contains(_event.target as Node))) {
-				if (typeof binding.value === "function") {
-					// Call the function directly if it's a function
-					binding.value(event)
-				} else if (typeof binding.value.handler === "function") {
-					// Call the handler with parameters if provided
-					binding.value.handler(event, ...(binding.value._args || []))
-				}
-			}
-		}
+                el.clickOutsideEvent = (_event: MouseEvent) => {
+                        // Check if the click was outside the element
+                        if (!(el === _event.target || el.contains(_event.target as Node))) {
+                                const bindingValue = binding.value as
+                                        | ClickOutsideHandler
+                                        | { handler?: ClickOutsideHandler; _args?: unknown[] }
+                                        | undefined
+                                if (typeof bindingValue === "function") {
+                                        // Call the function directly if it's a function
+                                        bindingValue(_event)
+                                } else if (bindingValue && typeof bindingValue.handler === "function") {
+                                        // Call the handler with parameters if provided
+                                        bindingValue.handler(_event, ...(bindingValue._args || []))
+                                }
+                        }
+                }
 		// Add event listener to the document
 		document.addEventListener("click", el.clickOutsideEvent)
 	},


### PR DESCRIPTION
## Summary
- wire dropdown menu to close when clicking outside or pressing escape and register DOM listeners safely
- fix the global click-outside directive so it forwards the actual mouse event to handlers instead of referencing an undefined variable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f0b976a60c832f88f874f69e8f127d