### PR TITLE
Adjust access token cookie configuration for HTTP deployments

### DIFF
--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -66,6 +66,18 @@ class AuthController extends Controller
         $property = $roleMap[$userRole] ?? null;
         $biodata = $property ? $user->$property : null;
 
+        $cookie = cookie(
+            'access_token',
+            $plainTextToken,
+            60,
+            '/',
+            config('session.domain'),
+            $request->isSecure() || config('session.secure', false),
+            true,
+            false,
+            config('session.same_site', 'lax')
+        );
+
         return response()->json([
             'success' => true,
             'user' => $user,
@@ -73,7 +85,7 @@ class AuthController extends Controller
             'role' => $user->role,
             'permissions' => $user->getAllPermissions()->pluck('name'),
             'token' => $plainTextToken,
-        ])->cookie('access_token', $plainTextToken, 60, null, null, true, true);
+        ])->withCookie($cookie);
     }
 
     public function logout(Request $request)


### PR DESCRIPTION
## Summary
- build the access token cookie using the application's session configuration instead of hard-coding HTTPS-only flags
- allow non-HTTPS environments to keep authentication cookies while preserving secure defaults when HTTPS is present

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f6e45f8470832f9d94a60b984cdb56